### PR TITLE
🐛 💄 Center thumbnail

### DIFF
--- a/src/components/CharacterBanner/index.scss
+++ b/src/components/CharacterBanner/index.scss
@@ -5,6 +5,10 @@
     padding: 1.5em;
     border: 0.4em solid lumx-color-variant('primary', 'N');
     border-radius: 10px;
+    
+    @media (max-width: 30em) {
+        grid-template-columns: none;
+    }
 
     .thumbnail {
         grid-row: 1;


### PR DESCRIPTION
In small device, the thumbnail wasn't center

Before
<img width="437" alt="image" src="https://github.com/LefebvreJonathan/frontend-tech-test/assets/38315793/86d52453-da38-4f79-8e4a-9795d546d15a">

After
<img width="431" alt="image" src="https://github.com/LefebvreJonathan/frontend-tech-test/assets/38315793/c24c0777-3a6a-4c2f-8fbe-5d0d0a539fbb">
